### PR TITLE
Avoid panic due to page index underflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ where
     use rand::{thread_rng, Rng};
 
     let mut rng = thread_rng();
-    let mut page: usize = rng.gen_range(0..=pages) - 1;
+    let mut page: usize = rng.gen_range(0..pages);
 
     let heap = mem.iter().filter(|m| m.perms == perms);
 


### PR DESCRIPTION
The page index will underflow, if the RNG chooses page 0.
Change the range to be exclusive-end and don't subtract one to avoid integer underflow.